### PR TITLE
Added missing entry in app.yaml for bootflat.css

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,6 +12,9 @@ handlers:
 - url: /loader.gif
   static_files: loader.gif
   upload: loader.gif
+- url: /bootflat.css
+  static_files: bootflat.css
+  upload: bootflat.css
 - url: /index.html
   static_files: index.html
   upload: index.html


### PR DESCRIPTION
A 404 error was being returned for the resource **/bootflat.css** when **index.html** was loaded in the browser.

I modified **app.yaml** adding an entry for **bootflat.css**.
